### PR TITLE
Extract request creation to simplify customization

### DIFF
--- a/src/Runner.php
+++ b/src/Runner.php
@@ -41,7 +41,7 @@ class Runner implements RunnerInterface
             // Merge the environment variables coming from DotEnv with the ones tied to the current request
             $_SERVER += $server;
 
-            $sfRequest = Request::createFromGlobals();
+            $sfRequest = $this->getSymfonyRequest();
             $sfResponse = $this->kernel->handle($sfRequest);
 
             $sfResponse->send();
@@ -59,5 +59,10 @@ class Runner implements RunnerInterface
         } while ($ret && (-1 === $this->loopMax || ++$loops < $this->loopMax));
 
         return 0;
+    }
+
+    protected function getSymfonyRequest(): Request
+    {
+        return Request::createFromGlobals();
     }
 }


### PR DESCRIPTION
Some apps (well, at least our!) extends Symfony Request (for legacy reasons and to add a few helpers), currently I need to duplicate the class to override Request, if we extract request creation it would be easier to extends.

Thank you!