### PR TITLE
Check for Xdebug cookie to determine when to debug

### DIFF
--- a/src/Runner.php
+++ b/src/Runner.php
@@ -34,7 +34,7 @@ class Runner implements RunnerInterface
 
         $handler = function () use ($server, &$sfRequest, &$sfResponse, $xdebugConnectToClient): void {
             // Connect to the Xdebug client if it's available
-            if ($xdebugConnectToClient) {
+            if ($xdebugConnectToClient && isset($_COOKIE['XDEBUG_SESSION'])) {
                 xdebug_connect_to_client();
             }
 


### PR DESCRIPTION
Check for XDEBUG_SESSION cookie, so we only connect to debugger when the debug toolbar has toggled it. This resembles how it works when you're not using the worker.

Kindly after merging also make a new release. https://github.com/php-runtime/frankenphp-symfony/commit/34b8c25e4b1043dec2a51dfebbc776260acf1921 is also not released yet.