### PR TITLE
Update Symfony package versions to include 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,9 @@
     ],
     "require": {
         "php": ">=8.1",
-        "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0",
-        "symfony/http-kernel": "^5.4 || ^6.0 || ^7.0",
-        "symfony/runtime": "^5.4 || ^6.0 || ^7.0"
+        "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0" || ^8.0",
+        "symfony/http-kernel": "^5.4 || ^6.0 || ^7.0 || ^8.0"",
+        "symfony/runtime": "^5.4 || ^6.0 || ^7.0 || ^8.0""
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5.58"


### PR DESCRIPTION
While trying https://github.com/dunglas/symfony-docker for a new Symfony 8 project, I encountered this error :

```
Loading composer repositories with package information
Restricting packages listed in "symfony/symfony" to "8.0.*"
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires runtime/frankenphp-symfony * -> satisfiable by runtime/frankenphp-symfony[0.1.0, 0.1.1, 0.2.0, 1.0.0].
    - runtime/frankenphp-symfony[0.1.0, ..., 0.1.1] require symfony/dependency-injection ^5.4 || ^6.0 -> found symfony/dependency-injection[v5.4.0, ..., v5.4.48, v6.0.0, ..., v6.4.30] but these were not loaded, likely because it conflicts with another require.
    - runtime/frankenphp-symfony[0.2.0, 1.0.0] require symfony/dependency-injection ^5.4 || ^6.0 || ^7.0 -> found symfony/dependency-injection[v5.4.0, ..., v5.4.48, v6.0.0, ..., v6.4.30, v7.0.0, ..., v7.4.2] but these were not loaded, likely because it conflicts with another require.
```

This PR aims to resolve that.